### PR TITLE
Fix cutpoints in precision_at_k 

### DIFF
--- a/src/Metrics Template.ipynb
+++ b/src/Metrics Template.ipynb
@@ -179,7 +179,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(12, 9));plt.plot(np.linspace(0.01, 1, 100), plot_dict['precision_at_k']['precision_at_k'], linewidth = 2);plt.title('Precision @ k', size = 20);plt.ylabel('Precision', size = 16);plt.xlabel('Top k risk (percent)', size = 16)\n",
+    "plt.figure(figsize=(12, 9));plt.plot(plot_dict['precision_at_k']['cutpoints'], plot_dict['precision_at_k']['precision_at_k'], linewidth = 2);plt.title('Precision @ k', size = 20);plt.ylabel('Precision', size = 16);plt.xlabel('Top k risk (percent)', size = 16)\n",
     "if save_figures: plt.savefig(output_dir + 'precision_at_k.png')\n",
     "plt.show()"
    ]

--- a/src/generate_plot_data.py
+++ b/src/generate_plot_data.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
             precision_k.append(y_true_temp.mean())
 
     precision_at_k_final = {'precision_at_k': precision_k,
-                            'cutpoints': list(cutpoints)}
+                            'cutpoints': list(np.linspace(0.01, 1, 100))}
     
     # Calibration ===================================================
     prob_true, prob_pred = calibration_curve(y_true, y_pred, n_bins = 10)


### PR DESCRIPTION
References #10 

Prior, the cutpoints did not refer to points on the x-axis of the associated plot for precision @ k. Now, the cutpoints in `plot_dict` refers to the x-axis of the associated plot and the `Metrics Template.ipynb` has been changed to accommodate this change.

The results were tested by re-running and noting that there is no change to the underlying graph even with the new implementation.