### PR TITLE
Add markdown title cell insertion for ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 data*
 checkpoint*
-
+.ipynb_checkpoints*
+.venv*
+.vscode*
+.DS_Store

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ seaborn = "*"
 papermill = "*"
 nbconvert = "*"
 rise = "*"
+pytest = "*"
 
 [dev-packages]
 

--- a/src/prepend_title_cell.py
+++ b/src/prepend_title_cell.py
@@ -1,0 +1,55 @@
+import json
+import nbformat as nbf
+import argparse
+import sys
+
+def add_ipynb_title(title: str, input_file: str, output_file: str, replace_first=False):
+    """Add or replaces the first cell of an ipython notebook with a markdown title
+
+    title (str): Markdown text to reside in the first cell
+    input_file (str): Path to the input file or template to be modified
+    output_file (str): Path to the write destination
+    replace_first (bool): If true, replaces the first cell of the input_file instead of prepending
+        a new cell
+
+    CLI use example:
+
+    python prepend_title.py -t '# New Header' -i 'Metrics Template.ipynb' -o 'my_notebook.ipynb'
+
+    """
+    # Ensure master template file won't be overwritten
+    if output_file.split('/')[-1]== 'Metrics Template.ipynb':
+        raise('Master Template overwrite is not permitted. Choose another output filepath')
+        sys.exit('1')
+    elif output_file.split('\\')[-1]== 'Metrics Template.ipynb': # ...Windows
+        raise('Master Template overwrite is not permitted. Choose another output filepath')
+        sys.exit('1')
+
+    # Create Title Cell
+    cell = nbf.v3.new_text_cell('markdown', title)
+
+    # Read in input_file ipynb
+    with open(input_file) as f:
+        data = json.load(f)
+    
+    met_nb = nbf.reads(json.dumps(data), as_version=4)
+
+    # Insert new cell at the front of the ipynb
+    if replace_first:
+        met_nb.get('cells')[0] = cell
+    else:
+        met_nb.get('cells').insert(0, cell)
+
+    # Write out the result
+    nbf.write(met_nb, output_file)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description = 'Add or replace the title cell of an ipython notebook')
+    parser.add_argument('--title', '-t', help='Title cell text you wish to add')
+    parser.add_argument('--input', '-i', help='Path to input ipynb file')
+    parser.add_argument('--output', '-o', help='Path to output ipynb file')
+    parser.add_argument('--replace', '-r', help='Replace an existing title cell', action='store_true')
+    args = parser.parse_args()
+
+    add_ipynb_title(args.title, args.input, args.output, args.replace)

--- a/src/prepend_title_cell.py
+++ b/src/prepend_title_cell.py
@@ -19,10 +19,10 @@ def add_ipynb_title(title: str, input_file: str, output_file: str, replace_first
     """
     # Ensure master template file won't be overwritten
     if output_file.split('/')[-1]== 'Metrics Template.ipynb':
-        raise('Master Template overwrite is not permitted. Choose another output filepath')
+        raise ValueError('Master Template overwrite is not permitted. Choose another output filepath')
         sys.exit('1')
     elif output_file.split('\\')[-1]== 'Metrics Template.ipynb': # ...Windows
-        raise('Master Template overwrite is not permitted. Choose another output filepath')
+        raise ValueError('Master Template overwrite is not permitted. Choose another output filepath')
         sys.exit('1')
 
     # Create Title Cell

--- a/tests/fixtures/ipynb_test.ipynb
+++ b/tests/fixtures/ipynb_test.ipynb
@@ -1,0 +1,271 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "save_figures = True\n",
+    "output_dir = \"../test/\"\n",
+    "input_file = \"../data/plot_data.json\"\n",
+    "model_results = \"../data/test.csv\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "plt.style.use('ggplot')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "with open(input_file, 'r') as f:\n",
+    "    plot_dict = json.load(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Model Metrics\n",
+    "\n",
+    "The following graphs have been automatically generated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## AUROC (Area Under Receiver Operating Characteristic) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9)); plt.plot(plot_dict['ROC']['fpr'], plot_dict['ROC']['tpr'], linewidth = 2); plt.title('ROC Curve', size = 20); plt.plot([0, 1], [0, 1], 'k--'); plt.annotate('AUROC: {:.2f} ({:.2f}, {:.2f})'.format(plot_dict['ROC']['auc'], plot_dict['ROC']['auc_lower_bound'], plot_dict['ROC']['auc_upper_bound']), [0.6, 0.4], fontsize = 16); plt.ylabel('True Positive Rate (Sensitivity, Recall)', size = 16); plt.xlabel('False Positive Rate', size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'auroc.png')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Class Probabilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "results = pd.read_csv(model_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9));sns.distplot(results.iloc[results.iloc[:, 0].values == 0, 1], kde = False, norm_hist = True, label = \"Negative\", bins = 30);sns.distplot(results.iloc[results.iloc[:, 0].values == 1, 1], kde = False, norm_hist = True, label = \"Positive\", bins = 30);plt.legend();plt.title(\"Distributions by class\", size = 20);plt.xlabel(\"Predicted Probability\", size = 16);plt.ylabel(\"Normalized Frequency\", size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'class_probabilities.png')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## Positive Predictive Value by Decile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9));sns.boxplot([1 - x for x in plot_dict['pid']['decile_midpoint']], plot_dict['pid']['pid']);plt.xticks(range(10), [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95]);plt.title('Positive Predictive Value in Decile of Risk', size = 20);plt.xlabel('Risk decile midpoint', size = 16);plt.ylabel('Positive Predictive Value (Precision)', size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'ppv_decile.png')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "##  Precision @ k"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9));plt.plot(plot_dict['precision_at_k']['cutpoints'], plot_dict['precision_at_k']['precision_at_k'], linewidth = 2);plt.title('Precision @ k', size = 20);plt.ylabel('Precision', size = 16);plt.xlabel('Top k risk (percent)', size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'precision_at_k.png')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Precision-Recall "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9));plt.plot(plot_dict['avg_precision']['recall'], plot_dict['avg_precision']['precision'], linewidth = 2);plt.title('Precision-Recall Curve', size = 20);plt.annotate('Average Precision: {:.2f} ({:.2f}, {:.2f})'.format(plot_dict['avg_precision']['avg_precision'], plot_dict['avg_precision']['avg_precision_lower_bound'], plot_dict['avg_precision']['avg_precision_upper_bound']), [0.4, 0.8], fontsize = 16);plt.ylabel('Positive Predictive Value (Precision)', size = 16);plt.xlabel('Recall', size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'precision_recall.png')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Calibration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(12, 9));plt.plot(plot_dict['calibration']['prob_pred'], plot_dict['calibration']['prob_true'], linewidth = 2);plt.title('Calibration Curve', size = 20);plt.plot([0, 1], [0, 1], 'k--');plt.ylabel('Empirical Probability', size = 16);plt.xlabel('Predicted Probability', size = 16)\n",
+    "if save_figures: plt.savefig(output_dir + 'calibration.png')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Slideshow",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "rise": {
+   "autolaunch": true,
+   "height": "100%",
+   "scroll": true,
+   "theme": "serif",
+   "width": "100%"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_prepend_title_cell.py
+++ b/tests/test_prepend_title_cell.py
@@ -1,0 +1,14 @@
+import os
+import json
+import pytest
+from src.prepend_title_cell import add_ipynb_title
+
+def test_prepend_title(tmpdir):
+    add_ipynb_title('test_title', 'tests/fixtures/ipynb_test.ipynb', f'{tmpdir}/out.ipynb')
+    with open(tmpdir.join('out.ipynb')) as f:
+        assert json.load(f).get('cells')[0].get('source') == ['test_title']
+
+def test_template_overwrite(tmpdir):
+    with pytest.raises(ValueError):
+        add_ipynb_title('test_title', 'tests/fixtures/ipynb_test.ipynb', f'{tmpdir}/Metrics Template.ipynb')
+        assert ValueError('Master Template overwrite is not permitted. Choose another output filepath') 


### PR DESCRIPTION
## Summary

The goal was to implement a solution that injects a cell into the javascript of an ipynb as a `papermill` input parameter. This implementation would move the cell addition step up prior to the `papermill` run and would change the papermill input file to be the output of the 'add title cell' step. 

```
Metrics Template.ipynb -> add_title_cell -> template_with_title -> papermill
```

This isn't as concise as a `papermill` javascript parameter injection but is more obvious / less hacky to implement and uses an established ipynb api package.  That said, I'm happy to return to attempting the `js` injection if that's still the ultimate ideal.

## Changes implemented

Adds a function to insert a new first cell or replace the first cell in an
existing ipython notebook with a markdown cell containing text provided.
Can use any ipynb as an input but will not output to any file named
'Metrics Template.ipynb'. This is currently hard coded until a more
elegant solution is devised.

## Other Information

`Pytest` was added to the `Pipenv` file along with basic tests for the developed function. 

[Papermill Extension](https://papermill.readthedocs.io/en/latest/extending-entry-points.html#developing-a-new-engine) may be another option.

Addresses: #1 

Would be interested in discussion / review.