### PR TITLE
Implementation of a thresholded confusion matrix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,5 @@ FROM python:3.7
 COPY requirements.txt /app/
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN jupyter nbextension enable --py widgetsnbextension
+

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ seaborn = "*"
 papermill = "*"
 nbconvert = "*"
 rise = "*"
+ipywidgets = "*"
 
 [dev-packages]
 

--- a/src/Metrics Template.ipynb
+++ b/src/Metrics Template.ipynb
@@ -5,7 +5,7 @@
    "execution_count": null,
    "metadata": {
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "slide"
     },
     "tags": [
      "parameters"
@@ -13,6 +13,7 @@
    },
    "outputs": [],
    "source": [
+    "# Default Arguments \n",
     "save_figures = True\n",
     "output_dir = \"../test/\"\n",
     "input_file = \"../data/plot_data.json\"\n",
@@ -24,31 +25,22 @@
    "execution_count": null,
    "metadata": {
     "slideshow": {
-     "slide_type": "skip"
+     "slide_type": "slide"
     }
    },
    "outputs": [],
    "source": [
+    "# Setup -- Make sure to execute this block to enable thresholding tool\n",
     "import json\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import seaborn as sns\n",
-    "plt.style.use('ggplot')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "outputs": [],
-   "source": [
+    "from ipywidgets import interact\n",
+    "plt.style.use('ggplot')\n",
     "with open(input_file, 'r') as f:\n",
-    "    plot_dict = json.load(f)"
+    "    plot_dict = json.load(f)\n",
+    "results = pd.read_csv(model_results)"
    ]
   },
   {
@@ -100,19 +92,6 @@
    },
    "source": [
     "# Class Probabilities"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "skip"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "results = pd.read_csv(model_results)"
    ]
   },
   {
@@ -236,6 +215,80 @@
     "plt.figure(figsize=(12, 9));plt.plot(plot_dict['calibration']['prob_pred'], plot_dict['calibration']['prob_true'], linewidth = 2);plt.title('Calibration Curve', size = 20);plt.plot([0, 1], [0, 1], 'k--');plt.ylabel('Empirical Probability', size = 16);plt.xlabel('Predicted Probability', size = 16)\n",
     "if save_figures: plt.savefig(output_dir + 'calibration.png')\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Thresholding "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def _generate_confusion_matrix(true, pred, threshold):\n",
+    "    true_series = pd.Series(true, name = 'True Label')\n",
+    "    pred_series = pd.Series([1 if x > threshold else 0 for x in pred], name = 'Predicted Label')\n",
+    "    return pd.crosstab(true_series, pred_series)\n",
+    "\n",
+    "def _get_metrics(confusion_matrix):\n",
+    "    tp = confusion_matrix.loc[1,1]\n",
+    "    fp = confusion_matrix.loc[0, 1]\n",
+    "    tn = confusion_matrix.loc[0, 0]\n",
+    "    fn = confusion_matrix.loc[1, 0]\n",
+    "    prevalence = (tp + fn) / (tp + fp + tn + fn)\n",
+    "    sensitivity = tp / (tp + fn)\n",
+    "    specificity  = tn / (tn + fp)\n",
+    "    ppv = tp / (tp + fp)\n",
+    "    npv = tn / (tn + fn)\n",
+    "    \n",
+    "    return tp, fp, tn, fn, prevalence, sensitivity, specificity, ppv, npv\n",
+    "\n",
+    "true = results.iloc[:, 0]\n",
+    "pred = results.iloc[:, 1]\n",
+    "\n",
+    "def print_metrics(threshold = 0.5):\n",
+    "    # Confusion_matrix\n",
+    "    print(\"Confusion Matrix at Threshold of {:.4f}\".format(threshold))\n",
+    "    print(\"\\n\")\n",
+    "    conf_mat = _generate_confusion_matrix(true, pred, threshold)\n",
+    "    print(conf_mat)\n",
+    "    tp, fp, tn, fn, prevalence, sensitivity, specificity, ppv, npv = _get_metrics(conf_mat)\n",
+    "    print(\"\\n\")\n",
+    "    print(\"=====================\")\n",
+    "    print(\"Metrics:\")\n",
+    "    print(\"=====================\")\n",
+    "    print(\"Prevalence of Outcome: {:.4f}\".format(prevalence))\n",
+    "    print(\"Sensitivity / Recall / True Positive Rate: {:.4f}\".format(sensitivity))\n",
+    "    print(\"Specificity / True Negative Rate: {:.4f}\".format(specificity))\n",
+    "    print(\"Positive predictive Value / Precision: {:.4f}\".format(ppv))\n",
+    "    print(\"Negative Predictive Value: {:.4f}\".format(npv))\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "interact(print_metrics, threshold = (0.01, 0.99, 0.01))"
    ]
   }
  ],


### PR DESCRIPTION
Addresses #6 

![thresholding](https://user-images.githubusercontent.com/13056349/60630591-ca9fc880-9dc8-11e9-838e-10c6a8b9b591.gif)

This enables a thresholding tool that allows the user to drag along a slider and to change the corresponding confusion matrix and some associated metrics.

There are a few potential improvements, which will be fleshed out into issues down the line.

The first is that this actually requires the cells to be executed, which is a bit of a burden (compared to the auto-generation of images using papermill parameters)

Also, this doesn't currently support model outputs which are ranked, but are not bounded on the interval [0,1]

